### PR TITLE
Update nuget dependence InfluxDB.Client

### DIFF
--- a/Serilog.Sinks.InfluxDB/Serilog.Sinks.InfluxDB.csproj
+++ b/Serilog.Sinks.InfluxDB/Serilog.Sinks.InfluxDB.csproj
@@ -49,7 +49,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="InfluxDB.Client" Version="1.16.0" />
+    <PackageReference Include="InfluxDB.Client" Version="1.19.0" />
     <PackageReference Include="Serilog" Version="2.10.0" />
     <PackageReference Include="Serilog.Sinks.PeriodicBatching" Version="2.3.0" />
   </ItemGroup>


### PR DESCRIPTION
#11 
Official InfluxDB.Client has updated to [1.19.0](https://www.nuget.org/packages/InfluxDB.Client/1.19.0).
Project which use newer version InfluxDB.Client can not use this sink normally.
It seen just update the dependence in Serilog.Sinks.InfluxDB.csproj can work fine in samples\Serilog.Sinks.InfluxDB.Console.AppSettings.