### PR TITLE
ExtendedTags

### DIFF
--- a/Serilog.Sinks.InfluxDB/Sinks/InfluxDB/InfluxDBSink.cs
+++ b/Serilog.Sinks.InfluxDB/Sinks/InfluxDB/InfluxDBSink.cs
@@ -128,7 +128,7 @@ namespace Serilog.Sinks.InfluxDB
                 {
                     if (logEvent.Properties.ContainsKey(extendedField))
                     {
-                        p = p.Field("releasenumber", logEvent.Properties[extendedField].ToString());
+                        p = p.Field(extendedField, logEvent.Properties[extendedField].ToString());
                     }
                 }
 

--- a/Serilog.Sinks.InfluxDB/Sinks/InfluxDB/InfluxDBSink.cs
+++ b/Serilog.Sinks.InfluxDB/Sinks/InfluxDB/InfluxDBSink.cs
@@ -81,8 +81,6 @@ namespace Serilog.Sinks.InfluxDB
             _extendedFields = options.ExtendedFields ?? Array.Empty<string>();
 
             _extendedTags = options.ExtendedTags ?? Array.Empty<string>();
-
-
         }
 
         /// <inheritdoc />
@@ -92,7 +90,6 @@ namespace Serilog.Sinks.InfluxDB
         /// <param name="events">The events to emit.</param>
         public Task EmitBatchAsync(IEnumerable<Events.LogEvent> batch)
         {
-            
             if (batch == null) throw new ArgumentNullException(nameof(batch));
 
             var logEvents = batch as List<Events.LogEvent> ?? batch.ToList();
@@ -116,22 +113,9 @@ namespace Serilog.Sinks.InfluxDB
                     .Field(Fields.Version, Fields.Values.Version)
                     .Timestamp(logEvent.Timestamp.UtcDateTime, WritePrecision.Ms);
 
-                foreach (var extendedTag in _extendedTags)
-                {
-                    if (logEvent.Properties.ContainsKey(extendedTag))
-                    {
-                        p = p.Tag(extendedTag, logEvent.Properties[extendedTag].ToString());
-                    }
-                }
+                p = p.ExtendTags(logEvent, _extendedTags);
 
-                foreach (var extendedField in _extendedFields)
-                {
-                    if (logEvent.Properties.ContainsKey(extendedField))
-                    {
-                        p = p.Field(extendedField, logEvent.Properties[extendedField].ToString());
-                    }
-                }
-
+                p = p.ExtendFields(logEvent, _extendedFields);
 
                 if (logEvent.Exception != null) p = p.Tag(Tags.ExceptionType, logEvent.Exception.GetType().Name);
 
@@ -266,7 +250,7 @@ namespace Serilog.Sinks.InfluxDB
         {
             var resource = new PermissionResource { Id = bucket.Id, OrgID = _connectionInfo.OrganizationId, Type = PermissionResource.TypeEnum.Buckets };
 
-            var write = new Permission(Permission.ActionEnum.Write, resource);
+            var write = new Permission(Permission.ActionEnum.Write, resource);            
             var authorizationRequest = new AuthorizationPostRequest(_connectionInfo.OrganizationId, permissions: new List<Permission> { write }, description: $"{nameof(Permission.ActionEnum.Write)} Token for Bucket '{bucket.Name}' (Serilog)");
             string token;
 

--- a/Serilog.Sinks.InfluxDB/Sinks/InfluxDB/InfluxDBSinkOptions.cs
+++ b/Serilog.Sinks.InfluxDB/Sinks/InfluxDB/InfluxDBSinkOptions.cs
@@ -17,5 +17,10 @@ namespace Serilog.Sinks.InfluxDB
 
         public IFormatProvider FormatProvider { get; set; } = null;
 
+        public string[] ExtendedTags { get; set; }
+
+        public string[] ExtendedFields { get; set; }
+
+
     }
 }

--- a/Serilog.Sinks.InfluxDB/Sinks/InfluxDB/PointExtensions.cs
+++ b/Serilog.Sinks.InfluxDB/Sinks/InfluxDB/PointExtensions.cs
@@ -1,0 +1,67 @@
+﻿using InfluxDB.Client.Writes;
+using Serilog.Events;
+
+namespace Serilog.Sinks.InfluxDB
+{
+    static class PointExtensions
+    {
+
+        public static PointData ExtendTags(this PointData p, Events.LogEvent logEvent, string[] tags)
+        {
+
+            foreach (var extendedTag in tags)
+            {
+                if (logEvent.Properties.ContainsKey(extendedTag))
+                {
+                    p = p.Tag(extendedTag, logEvent.Properties[extendedTag].ToString());
+                }
+            }
+            return p;
+
+        }
+
+        public static PointData ExtendFields(this PointData p, Events.LogEvent logEvent, string[] fields)
+        {
+
+            foreach (var extendedField in fields)
+            {
+                if (logEvent.Properties.ContainsKey(extendedField))
+                {
+                    var sv = logEvent.Properties[extendedField] as ScalarValue;
+                    switch (sv.Value)
+                    {
+                        case bool bl:
+                            p = p.Field(extendedField, bl);
+                            break;
+                        case int i:
+                            p = p.Field(extendedField, i);
+                            break;
+                        case double db:
+                            p = p.Field(extendedField, db);
+                            break;
+                        case decimal dc:
+                            p = p.Field(extendedField, dc);
+                            break;
+                        case long l:
+                            p = p.Field(extendedField, l);
+                            break;
+                        case uint ui:
+                            p = p.Field(extendedField, ui);
+                            break;
+                        case ulong u:
+                            p = p.Field(extendedField, u);
+                            break;
+                        case byte b:
+                            p = p.Field(extendedField, b);
+                            break;
+                        case null:
+                        default:
+                            p = p.Field(extendedField, logEvent.Properties[extendedField].ToString());
+                            break;
+                    }
+                }
+            }
+            return p;
+        }
+    }
+}

--- a/Tests/Serilog.Sinks.InfluxDB.Tests/PointExtensionsTest.cs
+++ b/Tests/Serilog.Sinks.InfluxDB.Tests/PointExtensionsTest.cs
@@ -1,0 +1,85 @@
+﻿using InfluxDB.Client.Writes;
+using Serilog.Events;
+using Serilog.Parsing;
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Serilog.Sinks.InfluxDB.Tests
+{
+    public class PointExtensionsTest
+    {
+
+        [Fact]
+        public void ValuesAreAddedToFields()
+        {
+
+            //Arrange
+            var testProperty = "Test Property";
+
+            var p = PointData.Measurement("test");
+
+            LogEventProperty[] properties = { new LogEventProperty(testProperty, new ScalarValue("Stored Value")) };
+
+            var le = new LogEvent(DateTime.Now, LogEventLevel.Error, new Exception(), new MessageTemplate("", Array.Empty<MessageTemplateToken>()), properties);
+
+            string[] fields = { testProperty };
+
+            //Act
+            p = PointExtensions.ExtendFields(p, le, fields);
+
+
+            //Assert
+            FieldInfo fi = typeof(PointData).GetField("_fields", BindingFlags.NonPublic | BindingFlags.Instance);
+
+            var _fields = (ImmutableSortedDictionary<string, object>)fi.GetValue(p);
+
+            Assert.Equal(1, _fields.Count);
+
+            _fields.TryGetValue(testProperty, out var storedValue);
+
+            Assert.Equal("\"Stored Value\"", storedValue);
+
+        }
+
+        [Fact]
+        public void ValuesAreAddedToTags()
+        {
+
+            //Arrange
+            var testProperty = "Test Property";
+
+            var p = PointData.Measurement("test");
+
+            LogEventProperty[] properties = { new LogEventProperty(testProperty, new ScalarValue("Stored Value")) };
+
+            var le = new LogEvent(DateTime.Now, LogEventLevel.Error, new Exception(), new MessageTemplate("", Array.Empty<MessageTemplateToken>()), properties);
+
+            string[] fields = { testProperty };
+
+            //Act
+            p = PointExtensions.ExtendTags(p, le, fields);
+
+
+            //Assert
+            FieldInfo fi = typeof(PointData).GetField("_tags", BindingFlags.NonPublic | BindingFlags.Instance);
+
+            var _tags = (ImmutableSortedDictionary<string, string>)fi.GetValue(p);
+
+            Assert.Equal(1, _tags.Count);
+
+            _tags.TryGetValue(testProperty, out var storedValue);
+
+            Assert.Equal("\"Stored Value\"", storedValue);
+
+        }
+
+
+
+    }
+}

--- a/samples/Serilog.Sinks.InfluxDB.Console.AppSettings/LoggingExtensions.cs
+++ b/samples/Serilog.Sinks.InfluxDB.Console.AppSettings/LoggingExtensions.cs
@@ -1,0 +1,17 @@
+﻿using Serilog.Configuration;
+using System;
+
+namespace Serilog.Sinks.InfluxDB.Console.AppSettings
+{
+    public static class LoggingExtensions
+    {
+        public static LoggerConfiguration WithReleaseNumber(
+            this LoggerEnrichmentConfiguration enrich)
+        {
+            if (enrich == null)
+                throw new ArgumentNullException(nameof(enrich));
+
+            return enrich.With<ReleaseNumberEnricher>();
+        }
+    }
+}

--- a/samples/Serilog.Sinks.InfluxDB.Console.AppSettings/Program.cs
+++ b/samples/Serilog.Sinks.InfluxDB.Console.AppSettings/Program.cs
@@ -35,7 +35,8 @@ namespace Serilog.Sinks.InfluxDB.Console.AppSettings
                 SelfLog.Enable(System.Console.Out);
                 host.UseSerilog((hostingContext, loggerConfiguration) =>
                 {
-                    loggerConfiguration.ReadFrom.Configuration(hostingContext.Configuration);
+                    loggerConfiguration.ReadFrom.Configuration(hostingContext.Configuration)
+                     .Enrich.WithReleaseNumber();
                 })
                 .ConfigureAppConfiguration((hostingContext, config) =>
                 {

--- a/samples/Serilog.Sinks.InfluxDB.Console.AppSettings/ReleaseNumberEnricher.cs
+++ b/samples/Serilog.Sinks.InfluxDB.Console.AppSettings/ReleaseNumberEnricher.cs
@@ -1,0 +1,40 @@
+﻿using Serilog.Core;
+using Serilog.Events;
+using System.Runtime.CompilerServices;
+
+namespace Serilog.Sinks.InfluxDB.Console.AppSettings
+{
+    public class ReleaseNumberEnricher : ILogEventEnricher
+    {
+        LogEventProperty _cachedProperty;
+
+        public const string PropertyName = "ReleaseNumber";
+
+        /// <summary>
+        /// Enrich the log event.
+        /// </summary>
+        /// <param name="logEvent">The log event to enrich.</param>
+        /// <param name="propertyFactory">Factory for creating new properties to add to the event.</param>
+        public void Enrich(LogEvent logEvent, ILogEventPropertyFactory propertyFactory)
+        {
+            logEvent.AddPropertyIfAbsent(GetLogEventProperty(propertyFactory));
+        }
+
+        private LogEventProperty GetLogEventProperty(ILogEventPropertyFactory propertyFactory)
+        {
+            // Don't care about thread-safety, in the worst case the field gets overwritten and one property will be GCed
+            if (_cachedProperty == null)
+                _cachedProperty = CreateProperty(propertyFactory);
+
+            return _cachedProperty;
+        }
+
+        // Qualify as uncommon-path
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static LogEventProperty CreateProperty(ILogEventPropertyFactory propertyFactory)
+        {
+            var value = 12;
+            return propertyFactory.CreateProperty(PropertyName, value);
+        }
+    }
+}

--- a/samples/Serilog.Sinks.InfluxDB.Console.AppSettings/appsettings.json
+++ b/samples/Serilog.Sinks.InfluxDB.Console.AppSettings/appsettings.json
@@ -32,7 +32,9 @@
             "BatchSizeLimit": 100,
             "Period": "0.00:00:30",
             "QueueLimit": 1000000
-          }
+          },
+          "ExtendedFields": [ "ReleaseNumber" ],
+          "ExtendedTags": []
         }
       }
     },


### PR DESCRIPTION
Allows fields and tags to be created in influxdb from the values available in the properties of the LogEvent object being processed

The name of the properties to be included are identified in the ExtendTags and ExtendFields properties