### PR TITLE
Added IncludeContextAttributes from Serilog Logger

### DIFF
--- a/Serilog.Sinks.InfluxDB/LoggerConfigurationInfluxDBExtensions.cs
+++ b/Serilog.Sinks.InfluxDB/LoggerConfigurationInfluxDBExtensions.cs
@@ -22,13 +22,14 @@ namespace Serilog
             LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,
             PeriodicBatchingSinkOptions batchingOptions = null,
             IFormatProvider formatProvider = null,
-            bool includeFullException = false)
+            bool includeFullException = false,
+            bool includeContextAttributes = false)
         {
             if (string.IsNullOrEmpty(uriString)) throw new ArgumentNullException(nameof(uriString));
             if (!Uri.TryCreate(uriString, UriKind.Absolute, out var _)) throw new ArgumentException($"Invalid uri : {uriString}");
 
             return InfluxDB(loggerConfiguration, applicationName, new Uri(uriString), organizationId, bucketName, instanceName,
-                token, restrictedToMinimumLevel, batchingOptions, formatProvider, includeFullException);
+                token, restrictedToMinimumLevel, batchingOptions, formatProvider, includeFullException, includeContextAttributes);
         }
 
         /// <summary>
@@ -45,7 +46,8 @@ namespace Serilog
             LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,
             PeriodicBatchingSinkOptions batchingOptions = null,
             IFormatProvider formatProvider = null,
-            bool includeFullException = false)
+            bool includeFullException = false,
+            bool includeContextAttributes = false)
         {
             if (uri == null) throw new ArgumentNullException(nameof(uri));
             if (loggerConfiguration == null) throw new ArgumentNullException(nameof(loggerConfiguration));
@@ -64,7 +66,8 @@ namespace Serilog
                 },
                 BatchOptions = batchingOptions,
                 FormatProvider = formatProvider,
-                IncludeFullException = includeFullException
+                IncludeFullException = includeFullException,
+                IncludeContextAttributes = includeContextAttributes
             };
 
             return InfluxDB(loggerConfiguration, sinkOptions, restrictedToMinimumLevel);

--- a/Serilog.Sinks.InfluxDB/Serilog.Sinks.InfluxDB.csproj
+++ b/Serilog.Sinks.InfluxDB/Serilog.Sinks.InfluxDB.csproj
@@ -13,50 +13,52 @@
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <RepositoryUrl>https://github.com/pada57/serilog-sinks-influxdb</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
-    <Version>2.1.1</Version>
+    <Version>2.1.2</Version>
     <PackageReleaseNotes>
-		2.1.1:
-		- Update nuget dependencies including InfluxDB.Client and Serilog.Sinks.PeriodicBatching
-		2.1.0 (only for InfluxDB v2.XX):
-		- New parameter IncludeFullException default to false
-		- Update nuget dependencies
-		2.0.3:
-		- Update nuget dependencies including InfluxDB.Client
-		2.0.2:
-		- Update nuget dependencies including InfluxDB.Client
-		2.0.1:
-		- Update nuget dependencies including InfluxDB.Client
-		2.0: Support for InfluxDB v2, not compatible with v1
-		- Change main dependency from InfluxData.Net to InfluxDB.Client
-		- Add two authentication mode with Token or Credentials (User/Password)
-		- Add new BatchOptions to have control over batch size / queue limit / period / eager first event emition
-		1.4.0 (only for InfluxDB v1.XX):
-		- New parameter IncludeFullException default to false
-		- Update nuget dependencies
-		1.3.2:
-		- Update nuget dependencies
-		1.3.1:
-		- Adapting namespaces
-		1.3:
-		- Handling of response with selflog and throwing exceptions letting PeriodicBatchingSink handling backoffs/retries
-		- Adding single InfluxDBSinkOptions for creating sink, kept backward compatibility for previous extension methods      -
-		- Add Benchmark tests and unit tests
-		- Add sample projects
-		- Add documentation and license (MIT)
-		- Removed unused method
-		1.2:
-		- Add instance name and rename source to application name
-		- Remove tag on message template
-		- Map facility to instance name
-		- Remove filtering of logevents and directly escape message after formatting
-		- Update to Serilog 2.10 and Serilog.Sinks.PeriodicBatching 2.3
-		1.1:
-		- Use Uri instead of address/port in extensions methods and also in InfluxDbCOnnectionInfo object
-		1.0:
-		- Forked fromhttps://github.com/ThiagoBarradas/serilog-sinks-influxdb
-		- Adaption for syslog format
-		- Fix 400 errors due to invalid characters with JSON payload
-	</PackageReleaseNotes>
+      2.1.2 :
+      - New parameter IncludeContextAttributes default to false
+      2.1.1:
+      - Update nuget dependencies including InfluxDB.Client and Serilog.Sinks.PeriodicBatching
+      2.1.0 (only for InfluxDB v2.XX):
+      - New parameter IncludeFullException default to false
+      - Update nuget dependencies
+      2.0.3:
+      - Update nuget dependencies including InfluxDB.Client
+      2.0.2:
+      - Update nuget dependencies including InfluxDB.Client
+      2.0.1:
+      - Update nuget dependencies including InfluxDB.Client
+      2.0: Support for InfluxDB v2, not compatible with v1
+      - Change main dependency from InfluxData.Net to InfluxDB.Client
+      - Add two authentication mode with Token or Credentials (User/Password)
+      - Add new BatchOptions to have control over batch size / queue limit / period / eager first event emition
+      1.4.0 (only for InfluxDB v1.XX):
+      - New parameter IncludeFullException default to false
+      - Update nuget dependencies
+      1.3.2:
+      - Update nuget dependencies
+      1.3.1:
+      - Adapting namespaces
+      1.3:
+      - Handling of response with selflog and throwing exceptions letting PeriodicBatchingSink handling backoffs/retries
+      - Adding single InfluxDBSinkOptions for creating sink, kept backward compatibility for previous extension methods      -
+      - Add Benchmark tests and unit tests
+      - Add sample projects
+      - Add documentation and license (MIT)
+      - Removed unused method
+      1.2:
+      - Add instance name and rename source to application name
+      - Remove tag on message template
+      - Map facility to instance name
+      - Remove filtering of logevents and directly escape message after formatting
+      - Update to Serilog 2.10 and Serilog.Sinks.PeriodicBatching 2.3
+      1.1:
+      - Use Uri instead of address/port in extensions methods and also in InfluxDbCOnnectionInfo object
+      1.0:
+      - Forked fromhttps://github.com/ThiagoBarradas/serilog-sinks-influxdb
+      - Adaption for syslog format
+      - Fix 400 errors due to invalid characters with JSON payload
+    </PackageReleaseNotes>
     <AssemblyVersion>2.1.1.0</AssemblyVersion>
     <FileVersion>2.1.1.0</FileVersion>
   </PropertyGroup>

--- a/Serilog.Sinks.InfluxDB/Sinks/InfluxDB/InfluxDBSinkOptions.cs
+++ b/Serilog.Sinks.InfluxDB/Sinks/InfluxDB/InfluxDBSinkOptions.cs
@@ -11,6 +11,8 @@ namespace Serilog.Sinks.InfluxDB
 
         public bool? IncludeFullException { get; set; } = false;
 
+        public bool? IncludeContextAttributes { get; set; } = false;
+
         public InfluxDBConnectionInfo ConnectionInfo { get; set; } = new InfluxDBConnectionInfo();
 
         public PeriodicBatchingSinkOptions BatchOptions { get; set; } = new PeriodicBatchingSinkOptions();


### PR DESCRIPTION
Hello 
The existing library is not supporting the context attributes as generated by the serilog logger.
Only the predefined tags and fields are generated in InfuxDB bucket.
I have extended the library, that now on demand , it will create the context attributes as tags in InfluxDB bucket.
Please review 