### PR TITLE
Fix #18:  Tags must not be quoted strings

### DIFF
--- a/Serilog.Sinks.InfluxDB/Sinks/InfluxDB/PointExtensions.cs
+++ b/Serilog.Sinks.InfluxDB/Sinks/InfluxDB/PointExtensions.cs
@@ -11,7 +11,7 @@ namespace Serilog.Sinks.InfluxDB
             {
                 if (logEvent.Properties.ContainsKey(extendedTag))
                 {
-                    builder.Tag(extendedTag, logEvent.Properties[extendedTag].ToString());
+                    builder.Tag(extendedTag, logEvent.Properties[extendedTag].ToString().Trim('"'));
                 }
             }
             return builder;

--- a/Tests/Serilog.Sinks.InfluxDB.Tests/PointExtensionsTest.cs
+++ b/Tests/Serilog.Sinks.InfluxDB.Tests/PointExtensionsTest.cs
@@ -65,6 +65,6 @@ public class PointExtensionsTest
 
         tags.TryGetValue(testProperty, out var storedValue);
 
-        Assert.Equal("\"Stored Value\"", storedValue);
+        Assert.Equal("Stored Value", storedValue);
     }
 }

--- a/Tests/Serilog.Sinks.InfluxDB.Tests/PointExtensionsTest.cs
+++ b/Tests/Serilog.Sinks.InfluxDB.Tests/PointExtensionsTest.cs
@@ -2,7 +2,7 @@
 using Serilog.Events;
 using Serilog.Parsing;
 using System;
-using System.Collections.Immutable;
+using System.Collections.Generic;
 using System.Reflection;
 using Xunit;
 
@@ -10,11 +10,9 @@ namespace Serilog.Sinks.InfluxDB.Tests;
 
 public class PointExtensionsTest
 {
-
     [Fact]
     public void ValuesAreAddedToFields()
     {
-
         //Arrange
         var testProperty = "Test Property";
 
@@ -24,29 +22,26 @@ public class PointExtensionsTest
 
         var le = new LogEvent(DateTime.Now, LogEventLevel.Error, new Exception(), new MessageTemplate("", Array.Empty<MessageTemplateToken>()), properties);
 
-        string[] fields = { testProperty };
+        string[] fieldNames = { testProperty };
 
         //Act
-        p.ExtendFields(le, fields);
-
+        p.ExtendFields(le, fieldNames);
 
         //Assert
-        FieldInfo fi = typeof(PointData).GetField("_fields", BindingFlags.NonPublic | BindingFlags.Instance);
+        FieldInfo fi = p.GetType().GetField("_fields", BindingFlags.NonPublic | BindingFlags.Instance);
 
-        var _fields = (ImmutableSortedDictionary<string, object>)fi.GetValue(p);
+        var fields = (IDictionary<string, object>)fi.GetValue(p);
 
-        Assert.Single(_fields);
+        Assert.Single(fields);
 
-        _fields.TryGetValue(testProperty, out var storedValue);
+        fields.TryGetValue(testProperty, out var storedValue);
 
         Assert.Equal("\"Stored Value\"", storedValue);
-
     }
 
     [Fact]
     public void ValuesAreAddedToTags()
     {
-
         //Arrange
         var testProperty = "Test Property";
 
@@ -56,24 +51,20 @@ public class PointExtensionsTest
 
         var le = new LogEvent(DateTime.Now, LogEventLevel.Error, new Exception(), new MessageTemplate("", Array.Empty<MessageTemplateToken>()), properties);
 
-        string[] fields = { testProperty };
+        string[] tagNames = { testProperty };
 
         //Act
-        p = p.ExtendTags(le, fields);
+        p.ExtendTags(le, tagNames);
 
         //Assert
-        FieldInfo fi = typeof(PointData).GetField("_tags", BindingFlags.NonPublic | BindingFlags.Instance);
+        FieldInfo fi = p.GetType().GetField("_tags", BindingFlags.NonPublic | BindingFlags.Instance);
 
-        var _tags = (ImmutableSortedDictionary<string, string>)fi.GetValue(p);
+        var tags = (IDictionary<string, string>)fi.GetValue(p);
 
-        Assert.Single(_tags);
+        Assert.Single(tags);
 
-        _tags.TryGetValue(testProperty, out var storedValue);
+        tags.TryGetValue(testProperty, out var storedValue);
 
         Assert.Equal("\"Stored Value\"", storedValue);
-
     }
-
-
-
 }


### PR DESCRIPTION
Fix #18: Using extended tags corrupts database