### PR TITLE
Change ProcId from int to string to match V2 change and the RFC.

### DIFF
--- a/Serilog.Sinks.InfluxDB/Serilog.Sinks.InfluxDB.csproj
+++ b/Serilog.Sinks.InfluxDB/Serilog.Sinks.InfluxDB.csproj
@@ -15,37 +15,37 @@
     <RepositoryType>git</RepositoryType>
     <Version>2.0.0-alpha.1</Version>    
     <PackageReleaseNotes>
-      2.0.0:
-      - A breaking change to ProcId logging from int to string
-      - A breaking change to severity_code from string to int
-      1.4.1:
-      - Update nuget dependency Serilog.Sinks.PeriodicBatching
-      1.4.0:
-      - New parameter IncludeFullException default to false
-      - Update nuget dependencies
-      1.3.2:
-      - Update nuget dependencies
-      1.3.1:
-      - Adapting namespaces
-      1.3:
-      - Handling of response with selflog and throwing exceptions letting PeriodicBatchingSink handling backoffs/retries
-      - Adding single InfluxDBSinkOptions for creating sink, kept backward compatibility for previous extension methods      -
-      - Add Benchmark tests and unit tests
-      - Add sample projects
-      - Add documentation and license (MIT)
-      - Removed unused method
-      1.2:
-      - Add instance name and rename source to application name
-      - Remove tag on message template
-      - Map facility to instance name
-      - Remove filtering of logevents and directly escape message after formatting
-      - Update to Serilog 2.10 and Serilog.Sinks.PeriodicBatching 2.3
-      1.1:
-      - Use Uri instead of address/port in extensions methods and also in InfluxDbCOnnectionInfo object
-      1.0:
-      - Forked fromhttps://github.com/ThiagoBarradas/serilog-sinks-influxdb
-      - Adaption for syslog format
-      - Fix 400 errors due to invalid characters with JSON payload</PackageReleaseNotes>
+    2.0.0:
+    - A breaking change to ProcId logging from int to string
+    - A breaking change to severity_code from string to int
+		1.4.1:
+		- Update nuget dependency Serilog.Sinks.PeriodicBatching
+		1.4.0:
+		- New parameter IncludeFullException default to false
+		- Update nuget dependencies
+		1.3.2:
+		- Update nuget dependencies
+		1.3.1:
+		- Adapting namespaces
+		1.3:
+		- Handling of response with selflog and throwing exceptions letting PeriodicBatchingSink handling backoffs/retries
+		- Adding single InfluxDBSinkOptions for creating sink, kept backward compatibility for previous extension methods      -
+		- Add Benchmark tests and unit tests
+		- Add sample projects
+		- Add documentation and license (MIT)
+		- Removed unused method
+		1.2:
+		- Add instance name and rename source to application name
+		- Remove tag on message template
+		- Map facility to instance name
+		- Remove filtering of logevents and directly escape message after formatting
+		- Update to Serilog 2.10 and Serilog.Sinks.PeriodicBatching 2.3
+		1.1:
+		- Use Uri instead of address/port in extensions methods and also in InfluxDbCOnnectionInfo object
+		1.0:
+		- Forked fromhttps://github.com/ThiagoBarradas/serilog-sinks-influxdb
+		- Adaption for syslog format
+		- Fix 400 errors due to invalid characters with JSON payload</PackageReleaseNotes>
     <AssemblyVersion>1.4.1.0</AssemblyVersion>
     <FileVersion>1.4.1.0</FileVersion>
   </PropertyGroup>

--- a/Serilog.Sinks.InfluxDB/Serilog.Sinks.InfluxDB.csproj
+++ b/Serilog.Sinks.InfluxDB/Serilog.Sinks.InfluxDB.csproj
@@ -4,7 +4,7 @@
     <Description>InfluxDB sink for Serilog with .NET standard 2.0 using syslog format for Influx1.X</Description>
     <Authors>Steven JABBOUR</Authors>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <PackageId>Serilog.Sinks.InfluxDB.Syslog</PackageId>
+    <PackageId>Serilog.Sinks.InfluxDBV1.Syslog</PackageId>
     <PackageTags>serilog;logging;semantic;structured;influxdb;netcore;netcore2;netstandard2;netstandard2.0</PackageTags>
     <PackageIconUrl>http://serilog.net/images/serilog-sink-nuget.png</PackageIconUrl>
     <PackageProjectUrl>https://github.com/pada57/serilog-sinks-influxdb</PackageProjectUrl>
@@ -13,36 +13,38 @@
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <RepositoryUrl>https://github.com/pada57/serilog-sinks-influxdb</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
-    <Version>1.4.1</Version>    
+    <Version>2.0.0-alpha.1</Version>    
     <PackageReleaseNotes>
-		1.4.1:
-		- Update nuget dependency Serilog.Sinks.PeriodicBatching
-		1.4.0:
-		- New parameter IncludeFullException default to false
-		- Update nuget dependencies
-		1.3.2:
-		- Update nuget dependencies
-		1.3.1:
-		- Adapting namespaces
-		1.3:
-		- Handling of response with selflog and throwing exceptions letting PeriodicBatchingSink handling backoffs/retries
-		- Adding single InfluxDBSinkOptions for creating sink, kept backward compatibility for previous extension methods      -
-		- Add Benchmark tests and unit tests
-		- Add sample projects
-		- Add documentation and license (MIT)
-		- Removed unused method
-		1.2:
-		- Add instance name and rename source to application name
-		- Remove tag on message template
-		- Map facility to instance name
-		- Remove filtering of logevents and directly escape message after formatting
-		- Update to Serilog 2.10 and Serilog.Sinks.PeriodicBatching 2.3
-		1.1:
-		- Use Uri instead of address/port in extensions methods and also in InfluxDbCOnnectionInfo object
-		1.0:
-		- Forked fromhttps://github.com/ThiagoBarradas/serilog-sinks-influxdb
-		- Adaption for syslog format
-		- Fix 400 errors due to invalid characters with JSON payload</PackageReleaseNotes>
+      2.0.0:
+      - A breaking change to ProcId logging from int to string
+      1.4.1:
+      - Update nuget dependency Serilog.Sinks.PeriodicBatching
+      1.4.0:
+      - New parameter IncludeFullException default to false
+      - Update nuget dependencies
+      1.3.2:
+      - Update nuget dependencies
+      1.3.1:
+      - Adapting namespaces
+      1.3:
+      - Handling of response with selflog and throwing exceptions letting PeriodicBatchingSink handling backoffs/retries
+      - Adding single InfluxDBSinkOptions for creating sink, kept backward compatibility for previous extension methods      -
+      - Add Benchmark tests and unit tests
+      - Add sample projects
+      - Add documentation and license (MIT)
+      - Removed unused method
+      1.2:
+      - Add instance name and rename source to application name
+      - Remove tag on message template
+      - Map facility to instance name
+      - Remove filtering of logevents and directly escape message after formatting
+      - Update to Serilog 2.10 and Serilog.Sinks.PeriodicBatching 2.3
+      1.1:
+      - Use Uri instead of address/port in extensions methods and also in InfluxDbCOnnectionInfo object
+      1.0:
+      - Forked fromhttps://github.com/ThiagoBarradas/serilog-sinks-influxdb
+      - Adaption for syslog format
+      - Fix 400 errors due to invalid characters with JSON payload</PackageReleaseNotes>
     <AssemblyVersion>1.4.1.0</AssemblyVersion>
     <FileVersion>1.4.1.0</FileVersion>
   </PropertyGroup>

--- a/Serilog.Sinks.InfluxDB/Serilog.Sinks.InfluxDB.csproj
+++ b/Serilog.Sinks.InfluxDB/Serilog.Sinks.InfluxDB.csproj
@@ -17,6 +17,7 @@
     <PackageReleaseNotes>
       2.0.0:
       - A breaking change to ProcId logging from int to string
+      - A breaking change to severity_code from string to int
       1.4.1:
       - Update nuget dependency Serilog.Sinks.PeriodicBatching
       1.4.0:

--- a/Serilog.Sinks.InfluxDB/Sinks/InfluxDB/InfluxDBSink.cs
+++ b/Serilog.Sinks.InfluxDB/Sinks/InfluxDB/InfluxDBSink.cs
@@ -99,7 +99,7 @@ namespace Serilog.Sinks.InfluxDB
                 // Add Fields - rendered message
                 p.Fields[Fields.Message] = StripSpecialCharacter(logEvent.RenderMessage(_formatProvider));
                 p.Fields[Fields.Facility] = 16;
-                p.Fields[Fields.ProcId] = Process.GetCurrentProcess().Id;
+                p.Fields[Fields.ProcId] = Process.GetCurrentProcess().Id.ToString();
                 p.Fields[Fields.Severity] = severity.ToString();
                 p.Fields[Fields.Timestamp] = logEvent.Timestamp.ToUnixTimeMilliseconds() * 1000000;
                 p.Fields[Fields.Version] = 1;

--- a/Serilog.Sinks.InfluxDB/Sinks/InfluxDB/InfluxDBSink.cs
+++ b/Serilog.Sinks.InfluxDB/Sinks/InfluxDB/InfluxDBSink.cs
@@ -100,7 +100,7 @@ namespace Serilog.Sinks.InfluxDB
                 p.Fields[Fields.Message] = StripSpecialCharacter(logEvent.RenderMessage(_formatProvider));
                 p.Fields[Fields.Facility] = 16;
                 p.Fields[Fields.ProcId] = Process.GetCurrentProcess().Id.ToString();
-                p.Fields[Fields.Severity] = severity.ToString();
+                p.Fields[Fields.Severity] = ((int)severity);
                 p.Fields[Fields.Timestamp] = logEvent.Timestamp.ToUnixTimeMilliseconds() * 1000000;
                 p.Fields[Fields.Version] = 1;
                 

--- a/Tests/Serilog.Sinks.InfluxDB.Tests/Serilog.Sinks.InfluxDB.Tests.csproj
+++ b/Tests/Serilog.Sinks.InfluxDB.Tests/Serilog.Sinks.InfluxDB.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/Tests/Serilog.Sinks.InfluxDb.Benchmarks/Serilog.Sinks.InfluxDB.Benchmarks.csproj
+++ b/Tests/Serilog.Sinks.InfluxDb.Benchmarks/Serilog.Sinks.InfluxDB.Benchmarks.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/Serilog.Sinks.InfluxDB.Console.AppSettings/Serilog.Sinks.InfluxDB.Console.AppSettings.csproj
+++ b/samples/Serilog.Sinks.InfluxDB.Console.AppSettings/Serilog.Sinks.InfluxDB.Console.AppSettings.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <AssemblyName>TestConsole</AssemblyName>
     <UserSecretsId>0ec930d4-a7ee-4491-8e98-c0ac84355615</UserSecretsId>
   </PropertyGroup>

--- a/samples/Serilog.Sinks.InfluxDB.Console.FluentConfig/Serilog.Sinks.InfluxDB.Console.FluentConfig.csproj
+++ b/samples/Serilog.Sinks.InfluxDB.Console.FluentConfig/Serilog.Sinks.InfluxDB.Console.FluentConfig.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <AssemblyName>TestConsole</AssemblyName>
     <UserSecretsId>0ec930d4-a7ee-4491-8e98-c0ac84355615</UserSecretsId>
   </PropertyGroup>


### PR DESCRIPTION
This is to resolve #29 and #30 

Small change to apply the ProcId fix from V2 to V1.
This is a bit dangerous, for anyone currently using it this will be a breaking change.

I have created a new package so we can test the fix quickly,  https://www.nuget.org/packages/Serilog.Sinks.InfluxDBV1.Syslog/2.0.0-alpha.1