### PR TITLE
Add option to include/exclude all default fields & customise measurement name #36

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ All those samples can be found under project subdirectory *samples* of this repo
 #### Optional parameters
 ```json
 "sinkOptions": {
+  "MeasurementName": "syslog",
   "ApplicationName": "testApp",
   "InstanceName": "testInstance",
   "IncludeFullException": true,

--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ All those samples can be found under project subdirectory *samples* of this repo
   "IncludeHostname": false,
   "IncludeLevel": true,
   "IncludeSeverity": true,
+  "IncludeDefaultFields": true,
   "ExtendedFields": ["ReleaseNumber"],
   "ExtendedTags": [],
   ...

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 [![Build](https://github.com/pada57/serilog-sinks-influxdb/actions/workflows/build.yml/badge.svg)](https://github.com/pada57/serilog-sinks-influxdb/actions/workflows/build.yml)
 [![nuget](https://img.shields.io/nuget/v/Serilog.Sinks.InfluxDB.Syslog.svg)](https://www.nuget.org/packages/Serilog.Sinks.InfluxDB.Syslog)
 
-A serilog sink that writes events to [InfluxDB](https://www.influxdata.com/) in syslog message format as described on the [Influx blog](https://www.influxdata.com/blog/writing-logs-directly-to-influxdb/).
+A serilog sink that writes events to [InfluxDB](https://www.influxdata.com/) in syslog message format (by default) as described on the [Influx blog](https://www.influxdata.com/blog/writing-logs-directly-to-influxdb/). The exact fields, tags and even measurement names can be customised via the sink configuration, as outlined below.
 Supports platforms compatible with the [.NET Platform Standard](https://docs.microsoft.com/en-us/dotnet/standard/net-standard) `netstandard2.0`.
 
 Compatible only with InfluxDB v2.0 and upwards
@@ -138,6 +138,33 @@ All those samples can be found under project subdirectory *samples* of this repo
   ...
 }
 ```
+
+#### Non-syslog format support
+Since initial creation of this plugin, InfluxDB now supports a more flexible logging approach that eliminates the strict requirement of the syslog format. This means it's possible to create leaner logging payloads without the additional syslog-specific entries with a configuration such as the following:
+
+```json
+"sinkOptions": {
+  "MeasurementName": "mymeasurement",
+  "IncludeHostname": false,
+  "IncludeLevel": false,
+  "IncludeSeverity": false,
+  "IncludeDefaultFields": false,
+  ...
+}
+```
+
+This configuration will produce a log entry with only a message and time:
+```json
+[
+  {
+    Time: DateTime_1,
+    Field: message,
+    Value: Some warning "Some parameter",
+    Tags: {}
+  }
+]
+```
+
 
 ### InfluxDB v1.X
 

--- a/Serilog.Sinks.InfluxDB/LoggerConfigurationInfluxDBExtensions.cs
+++ b/Serilog.Sinks.InfluxDB/LoggerConfigurationInfluxDBExtensions.cs
@@ -24,14 +24,15 @@ public static class LoggerConfigurationInfluxDBExtensions
         bool includeFullException = false, 
         bool includeHostname = true, 
         bool includeLevel = true, 
-        bool includeSeverity = true)
+        bool includeSeverity = true,
+        bool includeDefaultFields = true)
     {
         if (string.IsNullOrEmpty(uriString)) throw new ArgumentNullException(nameof(uriString));
         if (!Uri.TryCreate(uriString, UriKind.Absolute, out var _)) throw new ArgumentException($"Invalid uri : {uriString}");
 
         return InfluxDB(loggerConfiguration, applicationName, new Uri(uriString), organizationId, bucketName, instanceName,
             token, restrictedToMinimumLevel, batchingOptions, formatProvider, includeFullException, includeHostname, 
-            includeLevel, includeSeverity);
+            includeLevel, includeSeverity, includeDefaultFields);
     }
 
     /// <summary>
@@ -50,14 +51,15 @@ public static class LoggerConfigurationInfluxDBExtensions
         bool includeFullException = false,
         bool includeHostname = true,
         bool includeLevel = true,
-        bool includeSeverity = true)
+        bool includeSeverity = true,
+        bool includeDefaultFields = true)
     {
         if (string.IsNullOrEmpty(uriString)) throw new ArgumentNullException(nameof(uriString));
         if (!Uri.TryCreate(uriString, UriKind.Absolute, out var _)) throw new ArgumentException($"Invalid uri : {uriString}");
 
         return InfluxDB(loggerConfiguration, null, new Uri(uriString), organizationId, bucketName, null,
             token, restrictedToMinimumLevel, batchingOptions, formatProvider, includeFullException, includeHostname, 
-            includeLevel, includeSeverity);
+            includeLevel, includeSeverity, includeDefaultFields);
     }
 
     /// <summary>
@@ -77,7 +79,8 @@ public static class LoggerConfigurationInfluxDBExtensions
         bool includeFullException = false,
         bool includeHostname = true,
         bool includeLevel = true,
-        bool includeSeverity = true)
+        bool includeSeverity = true,
+        bool includeDefaultFields = true)
     {
         if (uri is null) throw new ArgumentNullException(nameof(uri));
         if (loggerConfiguration is null) throw new ArgumentNullException(nameof(loggerConfiguration));
@@ -99,7 +102,8 @@ public static class LoggerConfigurationInfluxDBExtensions
             IncludeFullException = includeFullException,
             IncludeHostname = includeHostname,
             IncludeLevel = includeLevel,
-            IncludeSeverity = includeSeverity
+            IncludeSeverity = includeSeverity,
+            IncludeDefaultFields = includeDefaultFields
         };
 
         return InfluxDB(loggerConfiguration, sinkOptions, restrictedToMinimumLevel);
@@ -121,7 +125,8 @@ public static class LoggerConfigurationInfluxDBExtensions
         bool includeFullException = false,
         bool includeHostname = true,
         bool includeLevel = true,
-        bool includeSeverity = true)
+        bool includeSeverity = true,
+        bool includeDefaultFields = true)
     {
         if (uri is null) throw new ArgumentNullException(nameof(uri));
         if (loggerConfiguration is null) throw new ArgumentNullException(nameof(loggerConfiguration));
@@ -141,7 +146,8 @@ public static class LoggerConfigurationInfluxDBExtensions
             IncludeFullException = includeFullException,
             IncludeHostname = includeHostname,
             IncludeLevel = includeLevel,
-            IncludeSeverity = includeSeverity
+            IncludeSeverity = includeSeverity,
+            IncludeDefaultFields = includeDefaultFields
         };
 
         return InfluxDB(loggerConfiguration, sinkOptions, restrictedToMinimumLevel);

--- a/Serilog.Sinks.InfluxDB/LoggerConfigurationInfluxDBExtensions.cs
+++ b/Serilog.Sinks.InfluxDB/LoggerConfigurationInfluxDBExtensions.cs
@@ -25,14 +25,15 @@ public static class LoggerConfigurationInfluxDBExtensions
         bool includeHostname = true, 
         bool includeLevel = true, 
         bool includeSeverity = true,
-        bool includeDefaultFields = true)
+        bool includeDefaultFields = true,
+        string? measurementName = null)
     {
         if (string.IsNullOrEmpty(uriString)) throw new ArgumentNullException(nameof(uriString));
         if (!Uri.TryCreate(uriString, UriKind.Absolute, out var _)) throw new ArgumentException($"Invalid uri : {uriString}");
 
         return InfluxDB(loggerConfiguration, applicationName, new Uri(uriString), organizationId, bucketName, instanceName,
             token, restrictedToMinimumLevel, batchingOptions, formatProvider, includeFullException, includeHostname, 
-            includeLevel, includeSeverity, includeDefaultFields);
+            includeLevel, includeSeverity, includeDefaultFields, measurementName);
     }
 
     /// <summary>
@@ -52,14 +53,15 @@ public static class LoggerConfigurationInfluxDBExtensions
         bool includeHostname = true,
         bool includeLevel = true,
         bool includeSeverity = true,
-        bool includeDefaultFields = true)
+        bool includeDefaultFields = true,
+        string? measurementName = null)
     {
         if (string.IsNullOrEmpty(uriString)) throw new ArgumentNullException(nameof(uriString));
         if (!Uri.TryCreate(uriString, UriKind.Absolute, out var _)) throw new ArgumentException($"Invalid uri : {uriString}");
 
         return InfluxDB(loggerConfiguration, null, new Uri(uriString), organizationId, bucketName, null,
             token, restrictedToMinimumLevel, batchingOptions, formatProvider, includeFullException, includeHostname, 
-            includeLevel, includeSeverity, includeDefaultFields);
+            includeLevel, includeSeverity, includeDefaultFields, measurementName);
     }
 
     /// <summary>
@@ -80,7 +82,8 @@ public static class LoggerConfigurationInfluxDBExtensions
         bool includeHostname = true,
         bool includeLevel = true,
         bool includeSeverity = true,
-        bool includeDefaultFields = true)
+        bool includeDefaultFields = true,
+        string? measurementName = null)
     {
         if (uri is null) throw new ArgumentNullException(nameof(uri));
         if (loggerConfiguration is null) throw new ArgumentNullException(nameof(loggerConfiguration));
@@ -99,6 +102,7 @@ public static class LoggerConfigurationInfluxDBExtensions
             },
             BatchOptions = batchingOptions,
             FormatProvider = formatProvider,
+            MeasurementName = measurementName,
             IncludeFullException = includeFullException,
             IncludeHostname = includeHostname,
             IncludeLevel = includeLevel,
@@ -126,7 +130,8 @@ public static class LoggerConfigurationInfluxDBExtensions
         bool includeHostname = true,
         bool includeLevel = true,
         bool includeSeverity = true,
-        bool includeDefaultFields = true)
+        bool includeDefaultFields = true,
+        string? measurementName = null)
     {
         if (uri is null) throw new ArgumentNullException(nameof(uri));
         if (loggerConfiguration is null) throw new ArgumentNullException(nameof(loggerConfiguration));
@@ -143,6 +148,7 @@ public static class LoggerConfigurationInfluxDBExtensions
             },
             BatchOptions = batchingOptions,
             FormatProvider = formatProvider,
+            MeasurementName = measurementName,
             IncludeFullException = includeFullException,
             IncludeHostname = includeHostname,
             IncludeLevel = includeLevel,

--- a/Serilog.Sinks.InfluxDB/Serilog.Sinks.InfluxDB.csproj
+++ b/Serilog.Sinks.InfluxDB/Serilog.Sinks.InfluxDB.csproj
@@ -18,8 +18,10 @@
     <RootNamespace>Serilog</RootNamespace>
     <EnableNETAnalyzers>true</EnableNETAnalyzers>
     <AnalysisMode>All</AnalysisMode>
-    <Version>2.3.4</Version>
+    <Version>2.3.5</Version>
     <PackageReleaseNotes>
+      2.3.5 (only for InfluxDB v2.XX):
+      - New parameter IncludeDefaultFields default to true to turn off all default fields
       2.3.4 (only for InfluxDB v2.XX):
       - New parameter IncludeHostname default to true
       - New parameter IncludeLevel default to true

--- a/Serilog.Sinks.InfluxDB/Serilog.Sinks.InfluxDB.csproj
+++ b/Serilog.Sinks.InfluxDB/Serilog.Sinks.InfluxDB.csproj
@@ -22,6 +22,7 @@
     <PackageReleaseNotes>
       2.3.5 (only for InfluxDB v2.XX):
       - New parameter IncludeDefaultFields default to true to turn off all default fields
+      - New parameter MeasurementName to allow measurement name to be customised
       2.3.4 (only for InfluxDB v2.XX):
       - New parameter IncludeHostname default to true
       - New parameter IncludeLevel default to true

--- a/Serilog.Sinks.InfluxDB/Sinks/InfluxDB/ExtensionMethods.cs
+++ b/Serilog.Sinks.InfluxDB/Sinks/InfluxDB/ExtensionMethods.cs
@@ -128,6 +128,15 @@ static class ExtensionMethods
         return builder;
     }
 
+    public static PointData.Builder OptionalField(this PointData.Builder builder, string name, object? value, bool? include)
+    {
+        if (include is true)
+        {
+            builder.Field(name, value);
+        }
+        return builder;
+    }
+
     private static (string, string) SplitIfColumnPresent(this string value)
     {
         var i = value.IndexOf(':');

--- a/Serilog.Sinks.InfluxDB/Sinks/InfluxDB/InfluxDBSink.cs
+++ b/Serilog.Sinks.InfluxDB/Sinks/InfluxDB/InfluxDBSink.cs
@@ -13,6 +13,7 @@ namespace Serilog.Sinks.InfluxDB;
 
 internal class InfluxDBSink : IBatchedLogEventSink, IDisposable
 {
+    private readonly string? _measurementName;
     private readonly string? _applicationName;
     private readonly string? _instanceName;
     private readonly string[]? _extendedTags;
@@ -60,6 +61,7 @@ internal class InfluxDBSink : IBatchedLogEventSink, IDisposable
         if (_authMethod == AuthMethods.Token && string.IsNullOrWhiteSpace(_connectionInfo.Token) && string.IsNullOrWhiteSpace(_connectionInfo.AllAccessToken) && string.IsNullOrWhiteSpace(_connectionInfo.Username))
             throw new ArgumentNullException(nameof(_connectionInfo.Token), $"At least one Token should be given either {nameof(_connectionInfo.Token)} if already created with write permissions or {nameof(_connectionInfo.AllAccessToken)}");
 
+        _measurementName = options.MeasurementName ?? MeasurementName;
         _applicationName = options.ApplicationName;
         _instanceName = options.InstanceName ?? _applicationName;
         _formatProvider = options.FormatProvider;
@@ -101,7 +103,7 @@ internal class InfluxDBSink : IBatchedLogEventSink, IDisposable
             // Skip the message if default fields are disabled and the message is blank
             var shouldLogMessage = _includeDefaultFields || !string.IsNullOrWhiteSpace(message);
 
-            var p = PointData.Builder.Measurement(PointName)
+            var p = PointData.Builder.Measurement(_measurementName)
                 .OptionalTag(Tags.AppName, _applicationName)
                 .OptionalTag(Tags.Facility, _instanceName)
                 .OptionalTag(Tags.Hostname, Environment.MachineName, _includeHostname)

--- a/Serilog.Sinks.InfluxDB/Sinks/InfluxDB/InfluxDBSinkOptions.cs
+++ b/Serilog.Sinks.InfluxDB/Sinks/InfluxDB/InfluxDBSinkOptions.cs
@@ -16,6 +16,8 @@ public class InfluxDBSinkOptions
     
     public bool? IncludeSeverity { get; set; } = true;
 
+    public bool? IncludeDefaultFields { get; set; } = true;
+
     public InfluxDBConnectionInfo? ConnectionInfo { get; set; } = new();
 
     public PeriodicBatchingSinkOptions? BatchOptions { get; set; } = new();

--- a/Serilog.Sinks.InfluxDB/Sinks/InfluxDB/InfluxDBSinkOptions.cs
+++ b/Serilog.Sinks.InfluxDB/Sinks/InfluxDB/InfluxDBSinkOptions.cs
@@ -4,6 +4,8 @@ namespace Serilog.Sinks.InfluxDB;
 
 public class InfluxDBSinkOptions
 {
+    public string? MeasurementName { get; set; }
+
     public string? ApplicationName { get; set; }
 
     public string? InstanceName { get; set; }

--- a/Serilog.Sinks.InfluxDB/Sinks/InfluxDB/SyslogConst.cs
+++ b/Serilog.Sinks.InfluxDB/Sinks/InfluxDB/SyslogConst.cs
@@ -2,7 +2,7 @@
 
 internal static class SyslogConst
 {
-    public const string PointName = "syslog";
+    public const string MeasurementName = "syslog";
 
     public static class Tags
     {

--- a/Tests/Serilog.Sinks.InfluxDB.Tests/InfluxDBSinkTests.GivenSpecificConfigurations.DefaultFieldsAreLoggedIfIncludeDefaultFieldsParameterIsTrue.verified.txt
+++ b/Tests/Serilog.Sinks.InfluxDB.Tests/InfluxDBSinkTests.GivenSpecificConfigurations.DefaultFieldsAreLoggedIfIncludeDefaultFieldsParameterIsTrue.verified.txt
@@ -1,0 +1,73 @@
+﻿[
+  {
+    Time: DateTime_1,
+    Field: facility_code,
+    Value: 16,
+    Tags: {
+      appname: TestApplication,
+      hostname: HOSTNAME,
+      level: Warning,
+      severity: warning
+    }
+  },
+  {
+    Time: DateTime_1,
+    Table: 1,
+    Field: message,
+    Value: Some warning "Some parameter",
+    Tags: {
+      appname: TestApplication,
+      hostname: HOSTNAME,
+      level: Warning,
+      severity: warning
+    }
+  },
+  {
+    Time: DateTime_1,
+    Table: 2,
+    Field: procid,
+    Value: PROCID,
+    Tags: {
+      appname: TestApplication,
+      hostname: HOSTNAME,
+      level: Warning,
+      severity: warning
+    }
+  },
+  {
+    Time: DateTime_1,
+    Table: 3,
+    Field: severity_code,
+    Value: warning,
+    Tags: {
+      appname: TestApplication,
+      hostname: HOSTNAME,
+      level: Warning,
+      severity: warning
+    }
+  },
+  {
+    Time: DateTime_1,
+    Table: 4,
+    Field: timestamp,
+    Value: TIMESTAMP,
+    Tags: {
+      appname: TestApplication,
+      hostname: HOSTNAME,
+      level: Warning,
+      severity: warning
+    }
+  },
+  {
+    Time: DateTime_1,
+    Table: 5,
+    Field: version,
+    Value: 1,
+    Tags: {
+      appname: TestApplication,
+      hostname: HOSTNAME,
+      level: Warning,
+      severity: warning
+    }
+  }
+]

--- a/Tests/Serilog.Sinks.InfluxDB.Tests/InfluxDBSinkTests.GivenSpecificConfigurations.DefaultFieldsAreLoggedIfIncludeDefaultFieldsParameterNotProvided.verified.txt
+++ b/Tests/Serilog.Sinks.InfluxDB.Tests/InfluxDBSinkTests.GivenSpecificConfigurations.DefaultFieldsAreLoggedIfIncludeDefaultFieldsParameterNotProvided.verified.txt
@@ -1,0 +1,73 @@
+﻿[
+  {
+    Time: DateTime_1,
+    Field: facility_code,
+    Value: 16,
+    Tags: {
+      appname: TestApplication,
+      hostname: HOSTNAME,
+      level: Warning,
+      severity: warning
+    }
+  },
+  {
+    Time: DateTime_1,
+    Table: 1,
+    Field: message,
+    Value: Some warning "Some parameter",
+    Tags: {
+      appname: TestApplication,
+      hostname: HOSTNAME,
+      level: Warning,
+      severity: warning
+    }
+  },
+  {
+    Time: DateTime_1,
+    Table: 2,
+    Field: procid,
+    Value: PROCID,
+    Tags: {
+      appname: TestApplication,
+      hostname: HOSTNAME,
+      level: Warning,
+      severity: warning
+    }
+  },
+  {
+    Time: DateTime_1,
+    Table: 3,
+    Field: severity_code,
+    Value: warning,
+    Tags: {
+      appname: TestApplication,
+      hostname: HOSTNAME,
+      level: Warning,
+      severity: warning
+    }
+  },
+  {
+    Time: DateTime_1,
+    Table: 4,
+    Field: timestamp,
+    Value: TIMESTAMP,
+    Tags: {
+      appname: TestApplication,
+      hostname: HOSTNAME,
+      level: Warning,
+      severity: warning
+    }
+  },
+  {
+    Time: DateTime_1,
+    Table: 5,
+    Field: version,
+    Value: 1,
+    Tags: {
+      appname: TestApplication,
+      hostname: HOSTNAME,
+      level: Warning,
+      severity: warning
+    }
+  }
+]

--- a/Tests/Serilog.Sinks.InfluxDB.Tests/InfluxDBSinkTests.GivenSpecificConfigurations.DefaultFieldsAreNotLoggedIfIncludeDefaultFieldsParameterIsFalse.verified.txt
+++ b/Tests/Serilog.Sinks.InfluxDB.Tests/InfluxDBSinkTests.GivenSpecificConfigurations.DefaultFieldsAreNotLoggedIfIncludeDefaultFieldsParameterIsFalse.verified.txt
@@ -1,0 +1,13 @@
+﻿[
+  {
+    Time: DateTime_1,
+    Field: message,
+    Value: Some warning "Some parameter",
+    Tags: {
+      appname: TestApplication,
+      hostname: HOSTNAME,
+      level: Warning,
+      severity: warning
+    }
+  }
+]

--- a/Tests/Serilog.Sinks.InfluxDB.Tests/InfluxDBSinkTests.GivenSpecificConfigurations.EmptyMessagesAreLogged.verified.txt
+++ b/Tests/Serilog.Sinks.InfluxDB.Tests/InfluxDBSinkTests.GivenSpecificConfigurations.EmptyMessagesAreLogged.verified.txt
@@ -1,0 +1,66 @@
+﻿[
+  {
+    Time: DateTime_1,
+    Field: facility_code,
+    Value: 16,
+    Tags: {
+      hostname: HOSTNAME,
+      level: Warning,
+      severity: warning
+    }
+  },
+  {
+    Time: DateTime_1,
+    Table: 1,
+    Field: message,
+    Tags: {
+      hostname: HOSTNAME,
+      level: Warning,
+      severity: warning
+    }
+  },
+  {
+    Time: DateTime_1,
+    Table: 2,
+    Field: procid,
+    Value: PROCID,
+    Tags: {
+      hostname: HOSTNAME,
+      level: Warning,
+      severity: warning
+    }
+  },
+  {
+    Time: DateTime_1,
+    Table: 3,
+    Field: severity_code,
+    Value: warning,
+    Tags: {
+      hostname: HOSTNAME,
+      level: Warning,
+      severity: warning
+    }
+  },
+  {
+    Time: DateTime_1,
+    Table: 4,
+    Field: timestamp,
+    Value: TIMESTAMP,
+    Tags: {
+      hostname: HOSTNAME,
+      level: Warning,
+      severity: warning
+    }
+  },
+  {
+    Time: DateTime_1,
+    Table: 5,
+    Field: version,
+    Value: 1,
+    Tags: {
+      hostname: HOSTNAME,
+      level: Warning,
+      severity: warning
+    }
+  }
+]

--- a/Tests/Serilog.Sinks.InfluxDB.Tests/InfluxDBSinkTests.GivenSpecificConfigurations.MeasurementNameIsLoggedAsSysLogIfIncludeMeasurementNameParameterNotProvided.verified.txt
+++ b/Tests/Serilog.Sinks.InfluxDB.Tests/InfluxDBSinkTests.GivenSpecificConfigurations.MeasurementNameIsLoggedAsSysLogIfIncludeMeasurementNameParameterNotProvided.verified.txt
@@ -1,0 +1,73 @@
+﻿[
+  {
+    Time: DateTime_1,
+    Field: facility_code,
+    Value: 16,
+    Tags: {
+      appname: TestApplication,
+      hostname: HOSTNAME,
+      level: Warning,
+      severity: warning
+    }
+  },
+  {
+    Time: DateTime_1,
+    Table: 1,
+    Field: message,
+    Value: Some warning "Some parameter",
+    Tags: {
+      appname: TestApplication,
+      hostname: HOSTNAME,
+      level: Warning,
+      severity: warning
+    }
+  },
+  {
+    Time: DateTime_1,
+    Table: 2,
+    Field: procid,
+    Value: PROCID,
+    Tags: {
+      appname: TestApplication,
+      hostname: HOSTNAME,
+      level: Warning,
+      severity: warning
+    }
+  },
+  {
+    Time: DateTime_1,
+    Table: 3,
+    Field: severity_code,
+    Value: warning,
+    Tags: {
+      appname: TestApplication,
+      hostname: HOSTNAME,
+      level: Warning,
+      severity: warning
+    }
+  },
+  {
+    Time: DateTime_1,
+    Table: 4,
+    Field: timestamp,
+    Value: TIMESTAMP,
+    Tags: {
+      appname: TestApplication,
+      hostname: HOSTNAME,
+      level: Warning,
+      severity: warning
+    }
+  },
+  {
+    Time: DateTime_1,
+    Table: 5,
+    Field: version,
+    Value: 1,
+    Tags: {
+      appname: TestApplication,
+      hostname: HOSTNAME,
+      level: Warning,
+      severity: warning
+    }
+  }
+]

--- a/Tests/Serilog.Sinks.InfluxDB.Tests/InfluxDBSinkTests.GivenSpecificConfigurations.MeasurementNameIsLoggedIfMeasurementNameParameterIsSpecified.verified.txt
+++ b/Tests/Serilog.Sinks.InfluxDB.Tests/InfluxDBSinkTests.GivenSpecificConfigurations.MeasurementNameIsLoggedIfMeasurementNameParameterIsSpecified.verified.txt
@@ -1,0 +1,73 @@
+﻿[
+  {
+    Time: DateTime_1,
+    Field: facility_code,
+    Value: 16,
+    Tags: {
+      appname: TestApplication,
+      hostname: HOSTNAME,
+      level: Warning,
+      severity: warning
+    }
+  },
+  {
+    Time: DateTime_1,
+    Table: 1,
+    Field: message,
+    Value: Some warning "Some parameter",
+    Tags: {
+      appname: TestApplication,
+      hostname: HOSTNAME,
+      level: Warning,
+      severity: warning
+    }
+  },
+  {
+    Time: DateTime_1,
+    Table: 2,
+    Field: procid,
+    Value: PROCID,
+    Tags: {
+      appname: TestApplication,
+      hostname: HOSTNAME,
+      level: Warning,
+      severity: warning
+    }
+  },
+  {
+    Time: DateTime_1,
+    Table: 3,
+    Field: severity_code,
+    Value: warning,
+    Tags: {
+      appname: TestApplication,
+      hostname: HOSTNAME,
+      level: Warning,
+      severity: warning
+    }
+  },
+  {
+    Time: DateTime_1,
+    Table: 4,
+    Field: timestamp,
+    Value: TIMESTAMP,
+    Tags: {
+      appname: TestApplication,
+      hostname: HOSTNAME,
+      level: Warning,
+      severity: warning
+    }
+  },
+  {
+    Time: DateTime_1,
+    Table: 5,
+    Field: version,
+    Value: 1,
+    Tags: {
+      appname: TestApplication,
+      hostname: HOSTNAME,
+      level: Warning,
+      severity: warning
+    }
+  }
+]

--- a/Tests/Serilog.Sinks.InfluxDB.Tests/InfluxDBSinkTests.GivenSpecificConfigurations.OnlyPropertiesAreLoggedLoggedIfIncludeDefaultFieldsParameterIsFalseAndMessageIsEmpty.verified.txt
+++ b/Tests/Serilog.Sinks.InfluxDB.Tests/InfluxDBSinkTests.GivenSpecificConfigurations.OnlyPropertiesAreLoggedLoggedIfIncludeDefaultFieldsParameterIsFalseAndMessageIsEmpty.verified.txt
@@ -1,0 +1,13 @@
+﻿[
+  {
+    Time: DateTime_1,
+    Field: MyField,
+    Value: value,
+    Tags: {
+      appname: TestApplication,
+      hostname: HOSTNAME,
+      level: Warning,
+      severity: warning
+    }
+  }
+]

--- a/Tests/Serilog.Sinks.InfluxDB.Tests/InfluxDBSinkTests.cs
+++ b/Tests/Serilog.Sinks.InfluxDB.Tests/InfluxDBSinkTests.cs
@@ -288,6 +288,100 @@ public static class InfluxDBSinkTests
         }
 
         [Fact]
+        public async Task DefaultFieldsAreLoggedIfIncludeDefaultFieldsParameterNotProvided()
+        {
+            Log.Logger = new LoggerConfiguration()
+                .WriteTo.InfluxDB(new InfluxDBSinkOptions
+                {
+                    ApplicationName = "TestApplication",
+                    InstanceName = string.Empty,
+                    ConnectionInfo = ConnectionInfo,
+                })
+                .CreateLogger();
+
+            Log.Warning("Some warning {Parameter}", "Some parameter");
+
+            await Log.CloseAndFlushAsync();
+
+            await Verify(GetAllRowsAsync());
+        }
+
+        [Fact]
+        public async Task DefaultFieldsAreLoggedIfIncludeDefaultFieldsParameterIsTrue()
+        {
+            Log.Logger = new LoggerConfiguration()
+                .WriteTo.InfluxDB(new InfluxDBSinkOptions
+                {
+                    ApplicationName = "TestApplication",
+                    InstanceName = string.Empty,
+                    ConnectionInfo = ConnectionInfo,
+                    IncludeDefaultFields = true
+                })
+                .CreateLogger();
+
+            Log.Warning("Some warning {Parameter}", "Some parameter");
+
+            await Log.CloseAndFlushAsync();
+
+            await Verify(GetAllRowsAsync());
+        }
+
+        [Fact]
+        public async Task DefaultFieldsAreNotLoggedIfIncludeDefaultFieldsParameterIsFalse()
+        {
+            Log.Logger = new LoggerConfiguration()
+                .WriteTo.InfluxDB(new InfluxDBSinkOptions
+                {
+                    ApplicationName = "TestApplication",
+                    InstanceName = string.Empty,
+                    ConnectionInfo = ConnectionInfo,
+                    IncludeDefaultFields = false,
+                })
+                .CreateLogger();
+
+            Log.Warning("Some warning {Parameter}", "Some parameter");
+
+            await Log.CloseAndFlushAsync();
+
+            await Verify(GetAllRowsAsync());
+        }
+
+        [Fact]
+        public async Task OnlyPropertiesAreLoggedLoggedIfIncludeDefaultFieldsParameterIsFalseAndMessageIsEmpty()
+        {
+            Log.Logger = new LoggerConfiguration()
+                .WriteTo.InfluxDB(new InfluxDBSinkOptions
+                {
+                    ApplicationName = "TestApplication",
+                    InstanceName = string.Empty,
+                    ConnectionInfo = ConnectionInfo,
+                    IncludeDefaultFields = false,
+                    ExtendedFields = new[] { "MyField" }
+                })
+                .CreateLogger();
+
+            Log.ForContext("MyField", "value").Warning("");
+
+            await Log.CloseAndFlushAsync();
+
+            await Verify(GetAllRowsAsync());
+        }
+
+        [Fact]
+        public async Task EmptyMessagesAreLogged()
+        {
+            Log.Logger = new LoggerConfiguration()
+                .WriteTo.InfluxDB(new InfluxDBSinkOptions { ConnectionInfo = ConnectionInfo })
+                .CreateLogger();
+
+            Log.Warning("");
+
+            await Log.CloseAndFlushAsync();
+
+            await Verify(GetAllRowsAsync());
+        }
+
+        [Fact]
         public async Task NoApplicationIsLoggedIfNotConfigured()
         {
             Log.Logger = new LoggerConfiguration()

--- a/Tests/Serilog.Sinks.InfluxDB.Tests/InfluxDBSinkTests.cs
+++ b/Tests/Serilog.Sinks.InfluxDB.Tests/InfluxDBSinkTests.cs
@@ -111,6 +111,45 @@ public static class InfluxDBSinkTests
         }
 
         [Fact]
+        public async Task MeasurementNameIsLoggedAsSysLogIfIncludeMeasurementNameParameterNotProvided()
+        {
+            Log.Logger = new LoggerConfiguration()
+                .WriteTo.InfluxDB(new InfluxDBSinkOptions
+                {
+                    ApplicationName = "TestApplication",
+                    InstanceName = string.Empty,
+                    ConnectionInfo = ConnectionInfo,
+                })
+                .CreateLogger();
+
+            Log.Warning("Some warning {Parameter}", "Some parameter");
+
+            await Log.CloseAndFlushAsync();
+
+            await Verify(GetAllRowsAsync());
+        }
+
+        [Fact]
+        public async Task MeasurementNameIsLoggedIfMeasurementNameParameterIsSpecified()
+        {
+            Log.Logger = new LoggerConfiguration()
+                .WriteTo.InfluxDB(new InfluxDBSinkOptions
+                {
+                    ApplicationName = "TestApplication",
+                    InstanceName = string.Empty,
+                    ConnectionInfo = ConnectionInfo,
+                    MeasurementName = "MyPoint"
+                })
+                .CreateLogger();
+
+            Log.Warning("Some warning {Parameter}", "Some parameter");
+
+            await Log.CloseAndFlushAsync();
+
+            await Verify(GetAllRowsAsync("MyPoint"));
+        }
+
+        [Fact]
         public async Task HostNameIsLoggedIfIncludeHostnameParameterNotProvided()
         {
             Log.Logger = new LoggerConfiguration()

--- a/Tests/Serilog.Sinks.InfluxDB.Tests/InfluxDBTestContainer.cs
+++ b/Tests/Serilog.Sinks.InfluxDB.Tests/InfluxDBTestContainer.cs
@@ -15,9 +15,9 @@ public class InfluxDBTestContainer : IAsyncLifetime, IAsyncDisposable
     public Bucket DefaultBucket { get; private set; } = null!;
     public ushort Port { get; private set; }
 
-    public async Task<ICollection<QueryResult>> GetAllRowsAsync()
+    public async Task<ICollection<QueryResult>> GetAllRowsAsync(string measurementName = "syslog")
     {
-        var rows = await GetAllRowsRawAsync();
+        var rows = await GetAllRowsRawAsync(measurementName: measurementName);
 
         // replace volatile values with constants to simplify testing.
         foreach (var row in rows)
@@ -45,14 +45,14 @@ public class InfluxDBTestContainer : IAsyncLifetime, IAsyncDisposable
         OrganizationId = DefaultBucket.OrgID
     };
 
-    private async Task<ICollection<QueryResult>> GetAllRowsRawAsync(string? bucketName = null)
+    private async Task<ICollection<QueryResult>> GetAllRowsRawAsync(string? bucketName = null, string measurementName = "syslog")
     {
         bucketName ??= DefaultBucket.Name;
 
         var query = $"""
     from(bucket: "{bucketName}")
       |> range(start: -1h)
-      |> filter(fn: (r) => r["_measurement"] == "syslog")
+      |> filter(fn: (r) => r["_measurement"] == "{measurementName}")
     """;
 
         var result = new List<QueryResult>();

--- a/samples/Serilog.Sinks.InfluxDB.Console.AppSettings/appsettings.json
+++ b/samples/Serilog.Sinks.InfluxDB.Console.AppSettings/appsettings.json
@@ -20,6 +20,7 @@
           "IncludeHostname": true,
           "IncludeLevel": true,
           "IncludeSeverity": true,
+          "IncludeDefaultFields": true,
           "ConnectionInfo": {
             "Uri": "http://localhost:8086",
             "BucketName": "logs",

--- a/samples/Serilog.Sinks.InfluxDB.Console.AppSettings/appsettings.json
+++ b/samples/Serilog.Sinks.InfluxDB.Console.AppSettings/appsettings.json
@@ -15,6 +15,7 @@
       "Name": "InfluxDB",
       "Args": {
         "sinkOptions": {
+          "MeasurementName": "syslog",
           "ApplicationName": "testApp",
           "InstanceName": "testInstance",
           "IncludeHostname": true,

--- a/samples/Serilog.Sinks.InfluxDB.Console.FluentConfig/Program.cs
+++ b/samples/Serilog.Sinks.InfluxDB.Console.FluentConfig/Program.cs
@@ -93,6 +93,7 @@ class Program
         Log.Logger = new LoggerConfiguration()
             .WriteTo.InfluxDB(new InfluxDBSinkOptions()
             {
+                MeasurementName = "syslog",
                 ApplicationName = "fluentSample",
                 InstanceName = "fluentSampleInstance",
                 ConnectionInfo = new InfluxDBConnectionInfo()

--- a/samples/Serilog.Sinks.InfluxDB.Console.FluentConfig/Program.cs
+++ b/samples/Serilog.Sinks.InfluxDB.Console.FluentConfig/Program.cs
@@ -117,7 +117,8 @@ class Program
                 IncludeFullException = true,
                 IncludeHostname = true,
                 IncludeLevel = true,
-                IncludeSeverity = true
+                IncludeSeverity = true,
+                IncludeDefaultFields = true
             })
             .CreateLogger();
 


### PR DESCRIPTION
Add option to include/exclude all default fields and option to change measurement name.

E.g.,
```
        "sinkOptions": {
          "MeasurementName": "syslog",
          "IncludeDefaultFields": true,
```

When `IncludeDefaultFields` is false, the message may be omitted too if it's empty or whitespace only.

Addresses #36